### PR TITLE
Arreglo bug bloque

### DIFF
--- a/Assets/Scripts/Fase construcción/draggable.cs
+++ b/Assets/Scripts/Fase construcción/draggable.cs
@@ -42,7 +42,7 @@ public class draggable : MonoBehaviour {
 
     private void Update() {
         casepoint = new Ray(transform.position, transform.up);
-        if (Physics.Raycast(casepoint, out hit, Mathf.Infinity, whatToDetect)) {
+        if (Physics.Raycast(casepoint, out hit, 0.1f, whatToDetect)) {
             canMove = false;
         }
         else {


### PR DESCRIPTION
Arreglado el bug que provoca que al colocar un bloque debajo de uno sin llegar a tocar (ej estando en una torres de 3), no permite mover el bloque de abajo